### PR TITLE
Remove unnecessary v-show that broke exit transitions

### DIFF
--- a/src/Flash.vue
+++ b/src/Flash.vue
@@ -71,8 +71,7 @@
                     message: message,
                     type: type,
                     typeObject: this.classes(this.types, type),
-                    iconObject: this.classes(this.icons, type),
-                    show: true
+                    iconObject: this.classes(this.icons, type)
                 });
                 setTimeout(this.hide, this.timeout);
             },
@@ -102,7 +101,6 @@
              */
             hide(item = this.notifications[0]) {
                 let key = this.notifications.indexOf(item);
-                this.notifications[key].show = false;
                 this.notifications.splice(key, 1);
             }
         },

--- a/src/Flash.vue
+++ b/src/Flash.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="alert-wrap">
         <transition-group :name="transition" tag="div">
-            <div :class="item.typeObject" role="alert" :key="index" v-show="item.show" v-for="(item, index) in notifications">
+            <div :class="item.typeObject" role="alert" :key="index" v-for="(item, index) in notifications">
                 <span v-if="displayIcons" :class="item.iconObject"></span> <span v-html="item.message"></span>
             </div>
         </transition-group>


### PR DESCRIPTION
`v-show` on each alert is unnecessary here, and in fact causes issues as it messes with Vue's ability to handle ending transitions. Removing `v-show` seems to have no downside as `v-for` handles the hiding and showing.

Issue before:

`Trigger a flash message > wait > then it disappears instantly.`
`Trigger multiple flash messages > wait > then first disappears instantly, others fade out at their time`.