### PR TITLE
Remove :key="index"

### DIFF
--- a/src/Flash.vue
+++ b/src/Flash.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="alert-wrap" v-if="notifications.length > 0">
         <transition-group :name="transition" tag="div">
-            <div :class="item.typeObject" role="alert" :key="index" v-for="(item, index) in notifications">
+            <div :class="item.typeObject" role="alert" v-for="(item, index) in notifications">
                 <span v-if="displayIcons" :class="item.iconObject"></span> <span v-html="item.message"></span>
             </div>
         </transition-group>


### PR DESCRIPTION
Vue.js will emit an Error when you use index as :key "Do not use v-for index as key on <transtion-group> children, this is the same as not using keys."

Just remove the :key="index"